### PR TITLE
Fix stage script failure handling

### DIFF
--- a/script/stage
+++ b/script/stage
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 red=$'\e[1;31m'
 grn=$'\e[1;32m'
 end=$'\e[0m'


### PR DESCRIPTION
## Summary
- ensure the `script/stage` deployment script stops on errors

## Testing
- `script/cibuild` *(fails: bundler not compatible with Ruby 3.2)*

------
https://chatgpt.com/codex/tasks/task_e_687a390135a8832f9556ca685734da91